### PR TITLE
🎉 Release 0.2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.2.13](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.13) - 2023-12-23
+
+### ❤️ Thanks to all contributors! ❤️
+
+@Psych0D0g
+
+### Misc
+
+- escape params ([5f791f4](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/5f791f4665f758d3308e2ad353080469f43cc27b))
+
 ## [0.2.12](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.12) - 2023-12-22
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   ](LICENSE)
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-  ![Version: 0.2.12](https://img.shields.io/badge/Version-0.2.12-informational?style=flat-square)
+  ![Version: 0.2.13](https://img.shields.io/badge/Version-0.2.13-informational?style=flat-square)
   ![AppVersion: 2.1.3](https://img.shields.io/badge/AppVersion-2.1.3-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/paperless-ngx)
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,7 +5,7 @@ name: paperless-ngx
 type: application
 home: https://github.com/CrystalNET-org/helm-paperless-ngx
 icon: https://avatars.githubusercontent.com/u/99562962?s=48&v=4
-version: 0.2.12
+version: 0.2.13
 # renovate: image=paperlessngx/paperless-ngx
 appVersion: "2.1.3"
 kubeVersion: ">=1.22.0-0"

--- a/chart/README.md
+++ b/chart/README.md
@@ -18,7 +18,7 @@
   ](LICENSE)
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-  ![Version: 0.2.12](https://img.shields.io/badge/Version-0.2.12-informational?style=flat-square)
+  ![Version: 0.2.13](https://img.shields.io/badge/Version-0.2.13-informational?style=flat-square)
   ![AppVersion: 2.1.3](https://img.shields.io/badge/AppVersion-2.1.3-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/paperless-ngx)
 


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.2.13` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.2.13](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.13) - 2023-12-23

### Misc

- escape params ([5f791f4](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/5f791f4665f758d3308e2ad353080469f43cc27b))