### PR TITLE
🎉 Release 0.2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.2.15](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.15) - 2024-01-02
+
+### ❤️ Thanks to all contributors! ❤️
+
+@psych0d0g
+
+### Misc
+
+- Update paperlessngx/paperless-ngx Docker tag to v2.2.1 [[#13](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/13)]
+- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.115.0 [[#12](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/12)]
+
 ## [0.2.14](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.14) - 2023-12-23
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
   ](LICENSE)
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-  ![Version: 0.2.14](https://img.shields.io/badge/Version-0.2.14-informational?style=flat-square)
-  ![AppVersion: 2.1.3](https://img.shields.io/badge/AppVersion-2.1.3-informational?style=flat-square)
+  ![Version: 0.2.15](https://img.shields.io/badge/Version-0.2.15-informational?style=flat-square)
+  ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/paperless-ngx)
 
 </div>

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,7 +5,7 @@ name: paperless-ngx
 type: application
 home: https://github.com/CrystalNET-org/helm-paperless-ngx
 icon: https://avatars.githubusercontent.com/u/99562962?s=48&v=4
-version: 0.2.14
+version: 0.2.15
 # renovate: image=paperlessngx/paperless-ngx
 appVersion: "2.2.1"
 kubeVersion: ">=1.22.0-0"

--- a/chart/README.md
+++ b/chart/README.md
@@ -18,8 +18,8 @@
   ](LICENSE)
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-  ![Version: 0.2.14](https://img.shields.io/badge/Version-0.2.14-informational?style=flat-square)
-  ![AppVersion: 2.1.3](https://img.shields.io/badge/AppVersion-2.1.3-informational?style=flat-square)
+  ![Version: 0.2.15](https://img.shields.io/badge/Version-0.2.15-informational?style=flat-square)
+  ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/paperless-ngx)
 
 </div>


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.2.15` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.2.15](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.15) - 2024-01-02

### Misc

- Update paperlessngx/paperless-ngx Docker tag to v2.2.1 [[#13](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/13)]
- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.115.0 [[#12](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/12)]