### PR TITLE
🎉 Release 0.2.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.2.15](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.15) - 2024-01-02
+
+### ❤️ Thanks to all contributors! ❤️
+
+@psych0d0g
+
+### Misc
+
+- Update paperlessngx/paperless-ngx Docker tag to v2.2.1 [[#13](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/13)]
+- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.115.0 [[#12](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/12)]
+
 ## [0.2.14](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.14) - 2023-12-23
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.2.16](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.16) - 2024-01-04
+
+### ❤️ Thanks to all contributors! ❤️
+
+@psych0d0g
+
+### Misc
+
+- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.121.0 [[#15](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/15)]
+
 ## [0.2.15](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.15) - 2024-01-02
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.2.17](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.17) - 2024-01-09
+
+### ❤️ Thanks to all contributors! ❤️
+
+@psych0d0g
+
+### Misc
+
+- Update paperlessngx/paperless-ngx Docker tag to v2.3.2 [[#21](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/21)]
+- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.126.3 [[#20](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/20)]
+
 ## [0.2.16](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.16) - 2024-01-07
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Misc
 
+- Update harbor.crystalnet.org/dockerhub-proxy/woodpeckerci/plugin-git Docker tag to v2.5.0 [[#33](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/33)]
+- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.173.0 [[#32](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/32)]
+- Update harbor.crystalnet.org/dockerhub-proxy/alpine/helm Docker tag to v3.14.0 [[#31](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/31)]
 - Update paperlessngx/paperless-ngx Docker tag to v2.4.3 [[#29](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/29)]
 - Update Helm release mariadb to ~15.2.0 [[#26](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/26)]
 - Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.140.10 [[#23](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/23)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Changelog
 
-## [0.2.17](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.17) - 2024-01-09
+## [0.2.17](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.17) - 2024-01-20
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@psych0d0g
+@Lukas Wingerberg, @psych0d0g
 
 ### Misc
 
+- Create .gitattributes ([0d42eaf](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/0d42eaf0488b648155a5ccfc38c237d9170c1ea2))
 - Update paperlessngx/paperless-ngx Docker tag to v2.3.2 [[#21](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/21)]
 - Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.126.3 [[#20](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/20)]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- Update paperlessngx/paperless-ngx Docker tag to v2.3.1 [[#19](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/19)]
 - Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.126.1 [[#18](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/18)]
 - Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.122.0 [[#17](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/17)]
 - Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.121.0 [[#15](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/15)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.2.16](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.16) - 2024-01-04
+## [0.2.16](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.16) - 2024-01-05
 
 ### ❤️ Thanks to all contributors! ❤️
 
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.122.0 [[#17](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/17)]
 - Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.121.0 [[#15](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/15)]
 
 ## [0.2.15](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.15) - 2024-01-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.2.16](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.16) - 2024-01-05
+## [0.2.16](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.16) - 2024-01-07
 
 ### ❤️ Thanks to all contributors! ❤️
 
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.126.1 [[#18](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/18)]
 - Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.122.0 [[#17](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/17)]
 - Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.121.0 [[#15](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/15)]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.140.10 [[#23](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/23)]
 - Update Helm release redis to ~18.7.0 [[#25](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/25)]
 - Update paperlessngx/paperless-ngx Docker tag to v2.4.0 [[#24](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/24)]
 - Update .gitattributes ([488ae73](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/488ae73be8aeff3313fd211faf2fb3d05ab15fb3))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- Update .gitattributes ([78dc2fe](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/78dc2feb5d39cd08ab4bbf6fa51de59728f50fbf))
 - Create .gitattributes ([0d42eaf](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/0d42eaf0488b648155a5ccfc38c237d9170c1ea2))
 - Update paperlessngx/paperless-ngx Docker tag to v2.3.2 [[#21](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/21)]
 - Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.126.3 [[#20](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/20)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- Update .gitattributes ([488ae73](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/488ae73be8aeff3313fd211faf2fb3d05ab15fb3))
 - Update .gitattributes ([78dc2fe](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/78dc2feb5d39cd08ab4bbf6fa51de59728f50fbf))
 - Create .gitattributes ([0d42eaf](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/0d42eaf0488b648155a5ccfc38c237d9170c1ea2))
 - Update paperlessngx/paperless-ngx Docker tag to v2.3.2 [[#21](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/21)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@Lukas Wingerberg, @psych0d0g
+@psych0d0g, @Lukas Wingerberg
 
 ### Misc
 
+- Update Helm release redis to ~18.7.0 [[#25](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/25)]
+- Update paperlessngx/paperless-ngx Docker tag to v2.4.0 [[#24](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/24)]
 - Update .gitattributes ([488ae73](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/488ae73be8aeff3313fd211faf2fb3d05ab15fb3))
 - Update .gitattributes ([78dc2fe](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/78dc2feb5d39cd08ab4bbf6fa51de59728f50fbf))
 - Create .gitattributes ([0d42eaf](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/0d42eaf0488b648155a5ccfc38c237d9170c1ea2))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.2.17](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.17) - 2024-01-20
+## [0.2.17](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.17) - 2024-02-05
 
 ### ❤️ Thanks to all contributors! ❤️
 
@@ -8,6 +8,8 @@
 
 ### Misc
 
+- Update paperlessngx/paperless-ngx Docker tag to v2.4.3 [[#29](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/29)]
+- Update Helm release mariadb to ~15.2.0 [[#26](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/26)]
 - Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.140.10 [[#23](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/23)]
 - Update Helm release redis to ~18.7.0 [[#25](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/25)]
 - Update paperlessngx/paperless-ngx Docker tag to v2.4.0 [[#24](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/24)]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   ](LICENSE)
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-  ![Version: 0.2.15](https://img.shields.io/badge/Version-0.2.15-informational?style=flat-square)
+  ![Version: 0.2.16](https://img.shields.io/badge/Version-0.2.16-informational?style=flat-square)
   ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/paperless-ngx)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
   ![Version: 0.2.17](https://img.shields.io/badge/Version-0.2.17-informational?style=flat-square)
-  ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
+  ![AppVersion: 2.4.3](https://img.shields.io/badge/AppVersion-2.4.3-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/paperless-ngx)
 
 </div>
@@ -65,7 +65,7 @@ Kubernetes: `>=1.22.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | mariadb(mariadb) | ~15.0.0 |
+| https://charts.bitnami.com/bitnami | mariadb(mariadb) | ~15.2.0 |
 | https://charts.bitnami.com/bitnami | postgresql(postgresql) | ~13.2.24 |
 | https://charts.bitnami.com/bitnami | redis(redis) | ~18.7.0 |
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
   ](LICENSE)
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-  ![Version: 0.2.14](https://img.shields.io/badge/Version-0.2.14-informational?style=flat-square)
-  ![AppVersion: 2.1.3](https://img.shields.io/badge/AppVersion-2.1.3-informational?style=flat-square)
+  ![Version: 0.2.15](https://img.shields.io/badge/Version-0.2.15-informational?style=flat-square)
+  ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/paperless-ngx)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
   ![Version: 0.2.16](https://img.shields.io/badge/Version-0.2.16-informational?style=flat-square)
-  ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
+  ![AppVersion: 2.3.1](https://img.shields.io/badge/AppVersion-2.3.1-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/paperless-ngx)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
   ![Version: 0.2.17](https://img.shields.io/badge/Version-0.2.17-informational?style=flat-square)
-  ![AppVersion: 2.3.2](https://img.shields.io/badge/AppVersion-2.3.2-informational?style=flat-square)
+  ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/paperless-ngx)
 
 </div>
@@ -67,7 +67,7 @@ Kubernetes: `>=1.22.0-0`
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | mariadb(mariadb) | ~15.0.0 |
 | https://charts.bitnami.com/bitnami | postgresql(postgresql) | ~13.2.24 |
-| https://charts.bitnami.com/bitnami | redis(redis) | ~18.6.0 |
+| https://charts.bitnami.com/bitnami | redis(redis) | ~18.7.0 |
 
 ## Installing the Chart
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
   ](LICENSE)
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-  ![Version: 0.2.16](https://img.shields.io/badge/Version-0.2.16-informational?style=flat-square)
-  ![AppVersion: 2.3.1](https://img.shields.io/badge/AppVersion-2.3.1-informational?style=flat-square)
+  ![Version: 0.2.17](https://img.shields.io/badge/Version-0.2.17-informational?style=flat-square)
+  ![AppVersion: 2.3.2](https://img.shields.io/badge/AppVersion-2.3.2-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/paperless-ngx)
 
 </div>

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,7 +5,7 @@ name: paperless-ngx
 type: application
 home: https://github.com/CrystalNET-org/helm-paperless-ngx
 icon: https://avatars.githubusercontent.com/u/99562962?s=48&v=4
-version: 0.2.16
+version: 0.2.17
 # renovate: image=paperlessngx/paperless-ngx
 appVersion: "2.3.2"
 kubeVersion: ">=1.22.0-0"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,7 +5,7 @@ name: paperless-ngx
 type: application
 home: https://github.com/CrystalNET-org/helm-paperless-ngx
 icon: https://avatars.githubusercontent.com/u/99562962?s=48&v=4
-version: 0.2.18
+version: 0.2.17
 # renovate: image=paperlessngx/paperless-ngx
 appVersion: "2.4.3"
 kubeVersion: ">=1.22.0-0"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,7 +5,7 @@ name: paperless-ngx
 type: application
 home: https://github.com/CrystalNET-org/helm-paperless-ngx
 icon: https://avatars.githubusercontent.com/u/99562962?s=48&v=4
-version: 0.2.14
+version: 0.2.15
 # renovate: image=paperlessngx/paperless-ngx
 appVersion: "2.2.1"
 kubeVersion: ">=1.22.0-0"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,7 +5,7 @@ name: paperless-ngx
 type: application
 home: https://github.com/CrystalNET-org/helm-paperless-ngx
 icon: https://avatars.githubusercontent.com/u/99562962?s=48&v=4
-version: 0.2.15
+version: 0.2.16
 # renovate: image=paperlessngx/paperless-ngx
 appVersion: "2.2.1"
 kubeVersion: ">=1.22.0-0"

--- a/chart/README.md
+++ b/chart/README.md
@@ -18,7 +18,7 @@
   ](LICENSE)
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-  ![Version: 0.2.15](https://img.shields.io/badge/Version-0.2.15-informational?style=flat-square)
+  ![Version: 0.2.16](https://img.shields.io/badge/Version-0.2.16-informational?style=flat-square)
   ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/paperless-ngx)
 

--- a/chart/README.md
+++ b/chart/README.md
@@ -19,7 +19,7 @@
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
   ![Version: 0.2.17](https://img.shields.io/badge/Version-0.2.17-informational?style=flat-square)
-  ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
+  ![AppVersion: 2.4.3](https://img.shields.io/badge/AppVersion-2.4.3-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/paperless-ngx)
 
 </div>
@@ -65,7 +65,7 @@ Kubernetes: `>=1.22.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | mariadb(mariadb) | ~15.0.0 |
+| https://charts.bitnami.com/bitnami | mariadb(mariadb) | ~15.2.0 |
 | https://charts.bitnami.com/bitnami | postgresql(postgresql) | ~13.2.24 |
 | https://charts.bitnami.com/bitnami | redis(redis) | ~18.7.0 |
 

--- a/chart/README.md
+++ b/chart/README.md
@@ -18,8 +18,8 @@
   ](LICENSE)
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-  ![Version: 0.2.14](https://img.shields.io/badge/Version-0.2.14-informational?style=flat-square)
-  ![AppVersion: 2.1.3](https://img.shields.io/badge/AppVersion-2.1.3-informational?style=flat-square)
+  ![Version: 0.2.15](https://img.shields.io/badge/Version-0.2.15-informational?style=flat-square)
+  ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/paperless-ngx)
 
 </div>

--- a/chart/README.md
+++ b/chart/README.md
@@ -19,7 +19,7 @@
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
   ![Version: 0.2.16](https://img.shields.io/badge/Version-0.2.16-informational?style=flat-square)
-  ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
+  ![AppVersion: 2.3.1](https://img.shields.io/badge/AppVersion-2.3.1-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/paperless-ngx)
 
 </div>

--- a/chart/README.md
+++ b/chart/README.md
@@ -19,7 +19,7 @@
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
   ![Version: 0.2.17](https://img.shields.io/badge/Version-0.2.17-informational?style=flat-square)
-  ![AppVersion: 2.3.2](https://img.shields.io/badge/AppVersion-2.3.2-informational?style=flat-square)
+  ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/paperless-ngx)
 
 </div>
@@ -67,7 +67,7 @@ Kubernetes: `>=1.22.0-0`
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | mariadb(mariadb) | ~15.0.0 |
 | https://charts.bitnami.com/bitnami | postgresql(postgresql) | ~13.2.24 |
-| https://charts.bitnami.com/bitnami | redis(redis) | ~18.6.0 |
+| https://charts.bitnami.com/bitnami | redis(redis) | ~18.7.0 |
 
 ## Installing the Chart
 

--- a/chart/README.md
+++ b/chart/README.md
@@ -18,8 +18,8 @@
   ](LICENSE)
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-  ![Version: 0.2.16](https://img.shields.io/badge/Version-0.2.16-informational?style=flat-square)
-  ![AppVersion: 2.3.1](https://img.shields.io/badge/AppVersion-2.3.1-informational?style=flat-square)
+  ![Version: 0.2.17](https://img.shields.io/badge/Version-0.2.17-informational?style=flat-square)
+  ![AppVersion: 2.3.2](https://img.shields.io/badge/AppVersion-2.3.2-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/paperless-ngx)
 
 </div>


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.2.17` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.2.17](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.17) - 2024-02-05

### Misc

- Update harbor.crystalnet.org/dockerhub-proxy/woodpeckerci/plugin-git Docker tag to v2.5.0 [[#33](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/33)]
- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.173.0 [[#32](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/32)]
- Update harbor.crystalnet.org/dockerhub-proxy/alpine/helm Docker tag to v3.14.0 [[#31](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/31)]
- Update paperlessngx/paperless-ngx Docker tag to v2.4.3 [[#29](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/29)]
- Update Helm release mariadb to ~15.2.0 [[#26](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/26)]
- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.140.10 [[#23](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/23)]
- Update Helm release redis to ~18.7.0 [[#25](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/25)]
- Update paperlessngx/paperless-ngx Docker tag to v2.4.0 [[#24](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/24)]
- Update .gitattributes ([488ae73](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/488ae73be8aeff3313fd211faf2fb3d05ab15fb3))
- Update .gitattributes ([78dc2fe](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/78dc2feb5d39cd08ab4bbf6fa51de59728f50fbf))
- Create .gitattributes ([0d42eaf](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/0d42eaf0488b648155a5ccfc38c237d9170c1ea2))
- Update paperlessngx/paperless-ngx Docker tag to v2.3.2 [[#21](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/21)]
- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.126.3 [[#20](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/20)]