### PR TITLE
🎉 Release 0.2.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.2.19](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.19) - 2024-10-29
+
+### ❤️ Thanks to all contributors! ❤️
+
+@psych0d0g
+
+### Misc
+
+- Update Helm release postgresql to v16 [[#51](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/51)]
+- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v38.134.0 [[#54](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/54)]
+- Update paperlessngx/paperless-ngx Docker tag to v2.13.1 [[#48](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/48)]
+- Update Helm release postgresql to ~14.3.0 [[#40](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/40)]
+
 ## [0.2.17](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.17) - 2024-02-05
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
   ](LICENSE)
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-  ![Version: 0.2.17](https://img.shields.io/badge/Version-0.2.17-informational?style=flat-square)
-  ![AppVersion: 2.4.3](https://img.shields.io/badge/AppVersion-2.4.3-informational?style=flat-square)
+  ![Version: 0.2.19](https://img.shields.io/badge/Version-0.2.19-informational?style=flat-square)
+  ![AppVersion: 2.13.1](https://img.shields.io/badge/AppVersion-2.13.1-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/paperless-ngx)
 
 </div>
@@ -66,8 +66,8 @@ Kubernetes: `>=1.22.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | mariadb(mariadb) | ~15.2.0 |
-| https://charts.bitnami.com/bitnami | postgresql(postgresql) | ~14.0.0 |
-| https://charts.bitnami.com/bitnami | redis(redis) | ~18.12.0 |
+| https://charts.bitnami.com/bitnami | postgresql(postgresql) | ~16.0.0 |
+| https://charts.bitnami.com/bitnami | redis(redis) | ~20.2.0 |
 
 ## Installing the Chart
 
@@ -219,7 +219,7 @@ The command removes all the Kubernetes components associated with the chart and 
 |-----|-------------|---------|
 | `ftpd_image.pullPolicy` | pull policy, if you set tag to latest, this should be set to Always to not end up with stale builds | `"IfNotPresent"` |
 | `ftpd_image.repository` | referencing the docker image to use for the ftpd component | `"harbor.crystalnet.org/library/paperless-ftpd"` |
-| `ftpd_image.tag` | Overrides the image tag whose default is the chart appVersion. | `"0.2.3"` |
+| `ftpd_image.tag` | Overrides the image tag whose default is the chart appVersion. | `"0.2.4"` |
 | `mediaVolume` | The list of additional volumes that will be mounted inside paperless pod, this one to `/paperless/library`. | See [values.yaml](./values.yaml) |
 | `postgresql.auth.database` | define database schema name that should be available | `"paperless"` |
 | `postgresql.auth.password` | password to connect to the database | `"changeme"` |

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,7 +5,7 @@ name: paperless-ngx
 type: application
 home: https://github.com/CrystalNET-org/helm-paperless-ngx
 icon: https://avatars.githubusercontent.com/u/99562962?s=48&v=4
-version: 0.2.21
+version: 0.2.19
 # renovate: image=paperlessngx/paperless-ngx
 appVersion: "2.13.1"
 kubeVersion: ">=1.22.0-0"

--- a/chart/README.md
+++ b/chart/README.md
@@ -18,8 +18,8 @@
   ](LICENSE)
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-  ![Version: 0.2.17](https://img.shields.io/badge/Version-0.2.17-informational?style=flat-square)
-  ![AppVersion: 2.4.3](https://img.shields.io/badge/AppVersion-2.4.3-informational?style=flat-square)
+  ![Version: 0.2.19](https://img.shields.io/badge/Version-0.2.19-informational?style=flat-square)
+  ![AppVersion: 2.13.1](https://img.shields.io/badge/AppVersion-2.13.1-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/paperless-ngx)
 
 </div>
@@ -66,8 +66,8 @@ Kubernetes: `>=1.22.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | mariadb(mariadb) | ~15.2.0 |
-| https://charts.bitnami.com/bitnami | postgresql(postgresql) | ~14.0.0 |
-| https://charts.bitnami.com/bitnami | redis(redis) | ~18.12.0 |
+| https://charts.bitnami.com/bitnami | postgresql(postgresql) | ~16.0.0 |
+| https://charts.bitnami.com/bitnami | redis(redis) | ~20.2.0 |
 
 ## Installing the Chart
 
@@ -219,7 +219,7 @@ The command removes all the Kubernetes components associated with the chart and 
 |-----|-------------|---------|
 | `ftpd_image.pullPolicy` | pull policy, if you set tag to latest, this should be set to Always to not end up with stale builds | `"IfNotPresent"` |
 | `ftpd_image.repository` | referencing the docker image to use for the ftpd component | `"harbor.crystalnet.org/library/paperless-ftpd"` |
-| `ftpd_image.tag` | Overrides the image tag whose default is the chart appVersion. | `"0.2.3"` |
+| `ftpd_image.tag` | Overrides the image tag whose default is the chart appVersion. | `"0.2.4"` |
 | `mediaVolume` | The list of additional volumes that will be mounted inside paperless pod, this one to `/paperless/library`. | See [values.yaml](./values.yaml) |
 | `postgresql.auth.database` | define database schema name that should be available | `"paperless"` |
 | `postgresql.auth.password` | password to connect to the database | `"changeme"` |


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.2.19` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.2.19](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.19) - 2024-10-29

### Misc

- Update Helm release postgresql to v16 [[#51](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/51)]
- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v38.134.0 [[#54](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/54)]
- Update paperlessngx/paperless-ngx Docker tag to v2.13.1 [[#48](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/48)]
- Update Helm release postgresql to ~14.3.0 [[#40](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/40)]