### PR TITLE
Update consumption to point to mountpoint

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -158,7 +158,7 @@ Create chart environment and make it reusable
 - name: PAPERLESS_CONSUMER_RECURSIVE
   value: {{ .Values.config.consumer.recursive | quote }}
 - name: PAPERLESS_CONSUMPTION_DIR
-  value: "/mnt/library/consume"
+  value: "/var/paperless/consume"
 - name: PAPERLESS_DATA_DIR
   value: "/var/paperless/data"
 - name: PAPERLESS_MEDIA_ROOT


### PR DESCRIPTION
This fixes an issue I noticed when deploying this chart where the consumption volume was not being used (and in fact was causing an error in the webservice container).

This fix updates PAPERLESS_CONSUMPTION_DIR to point to the volume mounted for this purpose, either as an emptyDir, or as a persistent volume, depending on other values.