### PR TITLE
🎉 Release 0.2.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- Update README.md ([387a8ba](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/387a8ba10e3f1f8bf68f2493ea976096aaf13e49))
 - Update README.md ([027d304](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/027d304dadfd58ae99121984ce269c8862e730bc))
 - Update Helm release postgresql to ~16.1.0 [[#58](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/58)]
 - Update paperlessngx/paperless-ngx Docker tag to v2.13.4 [[#56](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/56)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.2.23](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.23) - 2024-11-29
+
+### ❤️ Thanks to all contributors! ❤️
+
+@Cronix, @psych0d0g
+
+### Misc
+
+- Update README.md ([027d304](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/027d304dadfd58ae99121984ce269c8862e730bc))
+- Update Helm release postgresql to ~16.1.0 [[#58](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/58)]
+- Update paperlessngx/paperless-ngx Docker tag to v2.13.4 [[#56](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/56)]
+- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v38.142.6 [[#57](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/57)]
+
 ## [0.2.17](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.17) - 2024-02-05
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,19 @@
 # Changelog
 
-## [0.2.23](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.23) - 2024-11-29
+## [0.2.23](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.23) - 2026-07-08
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@Cronix, @psych0d0g
+@psych0d0g, @Psych0D0g, @Cronix
 
 ### Misc
 
+- Update quay.io/helmpack/chart-testing Docker tag to v3.12.0 [[#72](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/72)]
+- ci: fix deprecated secrets syntax flagged by woodpecker's linter ([8cfe9c7](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/8cfe9c7d4e7c357b2fc3ae3ae7c7f284bd971151))
+- Swap redis dependency for valkey (valkey-io's own chart, not Bitnami) ([a6db5de](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/a6db5dea719364c746996fdad95e136a64647202))
+- env: use raw EnvVar list instead of a plain string map ([379d953](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/379d9532520c09979f116d3b6204b46f86d1034b))
+- fix: PAPERLESS_CONSUMPTION_DIR is wrong when mediaVolume is disabled; add env passthrough ([43c95a2](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/43c95a20924fa0bbfa98b1caa7cd2dbde95e5a60))
+- fix: switch webserver command from gunicorn to granian, add migrate initContainer ([032f01d](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/032f01d9ce70b980d6e41ab0c51ed7097f220e4b))
 - Update README.md ([387a8ba](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/387a8ba10e3f1f8bf68f2493ea976096aaf13e49))
 - Update README.md ([027d304](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/027d304dadfd58ae99121984ce269c8862e730bc))
 - Update Helm release postgresql to ~16.1.0 [[#58](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/58)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- Update quay.io/helmpack/chart-releaser Docker tag to v1.7.0 [[#71](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/71)]
 - Update quay.io/helmpack/chart-testing Docker tag to v3.12.0 [[#72](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/72)]
 - ci: fix deprecated secrets syntax flagged by woodpecker's linter ([8cfe9c7](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/8cfe9c7d4e7c357b2fc3ae3ae7c7f284bd971151))
 - Swap redis dependency for valkey (valkey-io's own chart, not Bitnami) ([a6db5de](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/a6db5dea719364c746996fdad95e136a64647202))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@psych0d0g, @Psych0D0g, @Cronix
+@Cronix, @psych0d0g, @Psych0D0g
 
 ### Misc
 
+- Update renovate.yaml ([b4f2615](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/b4f2615e82eccbbc8778a12566e08bc335570031))
 - Update quay.io/helmpack/chart-releaser Docker tag to v1.7.0 [[#71](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/71)]
 - Update quay.io/helmpack/chart-testing Docker tag to v3.12.0 [[#72](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/72)]
 - ci: fix deprecated secrets syntax flagged by woodpecker's linter ([8cfe9c7](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/8cfe9c7d4e7c357b2fc3ae3ae7c7f284bd971151))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@Cronix, @psych0d0g, @Psych0D0g
+@psych0d0g, @Cronix, @Psych0D0g
 
 ### Misc
 
+- chore(deps): update harbor.crystalnet.org/dockerhub-proxy/woodpeckerci/plugin-git docker tag to v2.9.2 [[#74](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/74)]
 - Update renovate.yaml ([b4f2615](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/b4f2615e82eccbbc8778a12566e08bc335570031))
 - Update quay.io/helmpack/chart-releaser Docker tag to v1.7.0 [[#71](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/71)]
 - Update quay.io/helmpack/chart-testing Docker tag to v3.12.0 [[#72](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/72)]

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ helm install my-release oci://harbor.crystalnet.org/charts/paperless-ngx
 
 install using chartMuseum:
 ```shell
-helm repo add crystalnet https://helm.crystalnet.org
+helm repo add crystalnet https://charts.crystalnet.org
 helm install my-release crystalnet/paperless-ngx
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
   ](LICENSE)
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-  ![Version: 0.2.17](https://img.shields.io/badge/Version-0.2.17-informational?style=flat-square)
-  ![AppVersion: 2.4.3](https://img.shields.io/badge/AppVersion-2.4.3-informational?style=flat-square)
+  ![Version: 0.2.23](https://img.shields.io/badge/Version-0.2.23-informational?style=flat-square)
+  ![AppVersion: 2.13.4](https://img.shields.io/badge/AppVersion-2.13.4-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/paperless-ngx)
 
 </div>
@@ -45,7 +45,7 @@ helm install my-release oci://harbor.crystalnet.org/charts/paperless-ngx
 
 install using chartMuseum:
 ```shell
-helm repo add crystalnet https://helm.crystalnet.org
+helm repo add crystalnet https://charts.crystalnet.org
 helm install my-release crystalnet/paperless-ngx
 ```
 
@@ -65,9 +65,9 @@ Kubernetes: `>=1.22.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | mariadb(mariadb) | ~15.2.0 |
-| https://charts.bitnami.com/bitnami | postgresql(postgresql) | ~14.0.0 |
-| https://charts.bitnami.com/bitnami | redis(redis) | ~18.12.0 |
+| https://charts.bitnami.com/bitnami | mariadb(mariadb) | ~19.1.0 |
+| https://charts.bitnami.com/bitnami | postgresql(postgresql) | ~16.1.0 |
+| https://charts.bitnami.com/bitnami | redis(redis) | ~20.2.0 |
 
 ## Installing the Chart
 
@@ -219,7 +219,7 @@ The command removes all the Kubernetes components associated with the chart and 
 |-----|-------------|---------|
 | `ftpd_image.pullPolicy` | pull policy, if you set tag to latest, this should be set to Always to not end up with stale builds | `"IfNotPresent"` |
 | `ftpd_image.repository` | referencing the docker image to use for the ftpd component | `"harbor.crystalnet.org/library/paperless-ftpd"` |
-| `ftpd_image.tag` | Overrides the image tag whose default is the chart appVersion. | `"0.2.3"` |
+| `ftpd_image.tag` | Overrides the image tag whose default is the chart appVersion. | `"0.2.4"` |
 | `mediaVolume` | The list of additional volumes that will be mounted inside paperless pod, this one to `/paperless/library`. | See [values.yaml](./values.yaml) |
 | `postgresql.auth.database` | define database schema name that should be available | `"paperless"` |
 | `postgresql.auth.password` | password to connect to the database | `"changeme"` |

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,7 +5,7 @@ name: paperless-ngx
 type: application
 home: https://github.com/CrystalNET-org/helm-paperless-ngx
 icon: https://avatars.githubusercontent.com/u/99562962?s=48&v=4
-version: 0.3.0
+version: 0.2.23
 # renovate: image=paperlessngx/paperless-ngx
 appVersion: "2.20.15"
 kubeVersion: ">=1.22.0-0"

--- a/chart/README.md
+++ b/chart/README.md
@@ -18,8 +18,8 @@
   ](LICENSE)
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-  ![Version: 0.2.17](https://img.shields.io/badge/Version-0.2.17-informational?style=flat-square)
-  ![AppVersion: 2.4.3](https://img.shields.io/badge/AppVersion-2.4.3-informational?style=flat-square)
+  ![Version: 0.2.23](https://img.shields.io/badge/Version-0.2.23-informational?style=flat-square)
+  ![AppVersion: 2.13.4](https://img.shields.io/badge/AppVersion-2.13.4-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/paperless-ngx)
 
 </div>
@@ -65,9 +65,9 @@ Kubernetes: `>=1.22.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | mariadb(mariadb) | ~15.2.0 |
-| https://charts.bitnami.com/bitnami | postgresql(postgresql) | ~14.0.0 |
-| https://charts.bitnami.com/bitnami | redis(redis) | ~18.12.0 |
+| https://charts.bitnami.com/bitnami | mariadb(mariadb) | ~19.1.0 |
+| https://charts.bitnami.com/bitnami | postgresql(postgresql) | ~16.1.0 |
+| https://charts.bitnami.com/bitnami | redis(redis) | ~20.2.0 |
 
 ## Installing the Chart
 
@@ -219,7 +219,7 @@ The command removes all the Kubernetes components associated with the chart and 
 |-----|-------------|---------|
 | `ftpd_image.pullPolicy` | pull policy, if you set tag to latest, this should be set to Always to not end up with stale builds | `"IfNotPresent"` |
 | `ftpd_image.repository` | referencing the docker image to use for the ftpd component | `"harbor.crystalnet.org/library/paperless-ftpd"` |
-| `ftpd_image.tag` | Overrides the image tag whose default is the chart appVersion. | `"0.2.3"` |
+| `ftpd_image.tag` | Overrides the image tag whose default is the chart appVersion. | `"0.2.4"` |
 | `mediaVolume` | The list of additional volumes that will be mounted inside paperless pod, this one to `/paperless/library`. | See [values.yaml](./values.yaml) |
 | `postgresql.auth.database` | define database schema name that should be available | `"paperless"` |
 | `postgresql.auth.password` | password to connect to the database | `"changeme"` |


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.2.23` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.2.23](https://github.com/CrystalNET-org/helm-paperless-ngx/releases/tag/0.2.23) - 2026-07-08

### Misc

- chore(deps): update harbor.crystalnet.org/dockerhub-proxy/woodpeckerci/plugin-git docker tag to v2.9.2 [[#74](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/74)]
- Update renovate.yaml ([b4f2615](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/b4f2615e82eccbbc8778a12566e08bc335570031))
- Update quay.io/helmpack/chart-releaser Docker tag to v1.7.0 [[#71](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/71)]
- Update quay.io/helmpack/chart-testing Docker tag to v3.12.0 [[#72](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/72)]
- ci: fix deprecated secrets syntax flagged by woodpecker's linter ([8cfe9c7](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/8cfe9c7d4e7c357b2fc3ae3ae7c7f284bd971151))
- Swap redis dependency for valkey (valkey-io's own chart, not Bitnami) ([a6db5de](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/a6db5dea719364c746996fdad95e136a64647202))
- env: use raw EnvVar list instead of a plain string map ([379d953](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/379d9532520c09979f116d3b6204b46f86d1034b))
- fix: PAPERLESS_CONSUMPTION_DIR is wrong when mediaVolume is disabled; add env passthrough ([43c95a2](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/43c95a20924fa0bbfa98b1caa7cd2dbde95e5a60))
- fix: switch webserver command from gunicorn to granian, add migrate initContainer ([032f01d](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/032f01d9ce70b980d6e41ab0c51ed7097f220e4b))
- Update README.md ([387a8ba](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/387a8ba10e3f1f8bf68f2493ea976096aaf13e49))
- Update README.md ([027d304](https://github.com/CrystalNET-org/helm-paperless-ngx/commit/027d304dadfd58ae99121984ce269c8862e730bc))
- Update Helm release postgresql to ~16.1.0 [[#58](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/58)]
- Update paperlessngx/paperless-ngx Docker tag to v2.13.4 [[#56](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/56)]
- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v38.142.6 [[#57](https://github.com/CrystalNET-org/helm-paperless-ngx/pull/57)]